### PR TITLE
feat: open swagger page on launch when using vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,8 @@
       "stopAtEntry": false,
       "serverReadyAction": {
         "action": "openExternally",
-        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)",
+        "uriFormat": "%s/swagger/index.html"
       },
       "env": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
When debugging in vscode, swagger page is opened by default instead of the root url like before.